### PR TITLE
FIX: Correct font bundle to LatoFont.bundle

### DIFF
--- a/Source/UIFont+Lato.m
+++ b/Source/UIFont+Lato.m
@@ -26,12 +26,16 @@ static NSArray *fonts = nil;
               @"Lato-Black",
               @"Lato-BlackItalic"
               ];
-    
+
+    NSString* bundlePath = [[NSBundle mainBundle] pathForResource:@"LatoFont" ofType:@"bundle"];
+    NSBundle* bundleWithFonts = [NSBundle bundleWithPath:bundlePath];
+
     for (id font in fonts) {
-        NSURL *url = [[NSBundle mainBundle] URLForResource:font withExtension:@"ttf"];
+        NSURL *url = [bundleWithFonts URLForResource:font withExtension:@"ttf"];
         CFErrorRef error;
-        CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);
-        error = nil;
+        if (url) {
+            CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);
+        }
     }
 }
 


### PR DESCRIPTION
The podspec specifies that additional bundle should be created (`LatoFont.bundle`). 

However `UIFont+Lato` loads fonts from main bundle which leads to crash in `CTFontManagerRegisterFontsForURL` because `URLForResource:withExtension:` returns nil URL for non-existing files.
