### PR TITLE
Use of -bundleForClass: for getting resources

### DIFF
--- a/LatoFont.podspec
+++ b/LatoFont.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "LatoFont"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "Brings Lato font to iOS."
   s.homepage     = "https://github.com/michalkonturek/LatoFont"
   s.license      = 'MIT'
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = 'Source/*.{h,m}'
-  s.resource_bundle = { 'LatoFont' => 'Source/Fonts/*.ttf' }
+  s.resources = ["Source/Fonts/*.ttf"]
 
   s.requires_arc = true
 

--- a/LatoFont.podspec
+++ b/LatoFont.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   }
 
   s.source_files = 'Source/*.{h,m}'
-  s.resources = ["Source/Fonts/*.ttf"]
+  s.resource_bundle = { 'LatoFont' => 'Source/Fonts/*.ttf' }
 
   s.requires_arc = true
 

--- a/Source/UIFont+Lato.m
+++ b/Source/UIFont+Lato.m
@@ -10,6 +10,11 @@
 
 #import <CoreText/CoreText.h>
 
+@interface LatoFontFakeClass : NSObject
+@end
+@implementation LatoFontFakeClass
+@end
+
 static NSArray *fonts = nil;
 
 @implementation UIFont (Lato)
@@ -28,7 +33,7 @@ static NSArray *fonts = nil;
               ];
 
     for (id font in fonts) {
-        NSString *pathOfFont = [[NSBundle mainBundle] pathForResource:font ofType:@"ttf"];
+        NSString *pathOfFont = [[NSBundle bundleForClass:[LatoFontFakeClass class]] pathForResource:font ofType:@"ttf"];
         NSURL *url = [NSURL fileURLWithPath:pathOfFont];
         CFErrorRef error;
         if (url) {

--- a/Source/UIFont+Lato.m
+++ b/Source/UIFont+Lato.m
@@ -32,9 +32,12 @@ static NSArray *fonts = nil;
               @"Lato-BlackItalic"
               ];
 
+    NSBundle *bundle = [NSBundle bundleForClass:[LatoFontFakeClass class]];
+    NSString *bundlePath = [bundle pathForResource:@"LatoFont" ofType:@"bundle"];
+    NSBundle *bundleWithFonts = [NSBundle bundleWithPath:bundlePath];
+    
     for (id font in fonts) {
-        NSString *pathOfFont = [[NSBundle bundleForClass:[LatoFontFakeClass class]] pathForResource:font ofType:@"ttf"];
-        NSURL *url = [NSURL fileURLWithPath:pathOfFont];
+        NSURL *url = [bundleWithFonts URLForResource:font withExtension:@"ttf"];
         CFErrorRef error;
         if (url) {
             CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);

--- a/Source/UIFont+Lato.m
+++ b/Source/UIFont+Lato.m
@@ -27,11 +27,9 @@ static NSArray *fonts = nil;
               @"Lato-BlackItalic"
               ];
 
-    NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"LatoFont" ofType:@"bundle"];
-    NSBundle *bundleWithFonts = [NSBundle bundleWithPath:bundlePath];
-
     for (id font in fonts) {
-        NSURL *url = [bundleWithFonts URLForResource:font withExtension:@"ttf"];
+        NSString *pathOfFont = [[NSBundle mainBundle] pathForResource:font ofType:@"ttf"];
+        NSURL *url = [NSURL fileURLWithPath:pathOfFont];
         CFErrorRef error;
         if (url) {
             CTFontManagerRegisterFontsForURL((__bridge CFURLRef)url, kCTFontManagerScopeNone, &error);


### PR DESCRIPTION
Since cocoapods 0.36.1.beta, which introduces Frameworks and Swift, -bundleForClass must be used instead of mainBundle:
http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/

I've made the changes to make the pod compatible for that