### PR TITLE
Swift 3.0 changes

### DIFF
--- a/LatoFont/Classes/UIFont+Lato.swift
+++ b/LatoFont/Classes/UIFont+Lato.swift
@@ -34,16 +34,16 @@ extension UIFont {
             "Lato-BlackItalic"
         ]
         
-        let podBundle = Bundle(forClass: LatoFontFakeClass.self)
-        if let bundleURL = podBundle.URLForResource("LatoFont", withExtension: "bundle") {
-            if let bundle = Bundle(URL: bundleURL) {
+        let podBundle = Bundle(for: LatoFontFakeClass.self)
+        if let bundleURL = podBundle.url(forResource: "LatoFont", withExtension: "bundle") {
+            if let bundle = Bundle(url: bundleURL) {
                 
                 for font in fonts {
-                    let url = bundle.URLForResource(font, withExtension: "ttf")
+                    let url = bundle.url(forResource: font, withExtension: "ttf")
                     
                     if (url != nil) {
                         var errorRef: Unmanaged<CFError>?
-                        CTFontManagerRegisterFontsForURL(url!, .None, &errorRef)
+                        CTFontManagerRegisterFontsForURL(url! as CFURL, .none, &errorRef)
                     }
                 }
             }

--- a/LatoFont/Classes/UIFont+Lato.swift
+++ b/LatoFont/Classes/UIFont+Lato.swift
@@ -20,7 +20,7 @@ extension UIFont {
 
     @nonobjc static var fonts: [String]!
     
-    override public class func initialize() {
+    override open class func initialize() {
         fonts = [
             "Lato-Hairline",
             "Lato-HairlineItalic",
@@ -34,9 +34,9 @@ extension UIFont {
             "Lato-BlackItalic"
         ]
         
-        let podBundle = NSBundle(forClass: LatoFontFakeClass.self)
+        let podBundle = Bundle(forClass: LatoFontFakeClass.self)
         if let bundleURL = podBundle.URLForResource("LatoFont", withExtension: "bundle") {
-            if let bundle = NSBundle(URL: bundleURL) {
+            if let bundle = Bundle(URL: bundleURL) {
                 
                 for font in fonts {
                     let url = bundle.URLForResource(font, withExtension: "ttf")


### PR DESCRIPTION
Wanted to use this in a Swift 3.0 project. I'm pretty new to Swift and iOS scene, so this was based of XCode's migration. I don't know how/when something like Swift3 version gets merged and tagged, but if anyone wants it now

```
  pod 'LatoFont', :git => 'https://github.com/tomtomau/LatoFont.git', :branch => 'swift-3.0'
```
